### PR TITLE
Add an explicit soapboxing limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ This list is not exhaustive; if a behavior is not listed here, that does not mea
 	* Harming their friends, family, and/or pets.
 	* Attacking their livelihood (e.g. trying to get someone removed from their job or volunteer positions).
 	* Blackmail.
+* Habitually using `##llamas` to promote political ideas without participating in any following critical examination of those ideas.
 * Bringing personal drama or drama from other channels to `##llamas`.
 
 ### Examples of Permissible Behavior


### PR DESCRIPTION
This change adds a line to the `##llamas` ruleset that has previously been discussed by the ops. There is a slight change in wording to clarify that one is not required to critically examine their own opinion if no-one else challenges it, even though it would be good to do so.